### PR TITLE
Fix bindShared in Laravel 5.2

### DIFF
--- a/src/MollomServiceProvider.php
+++ b/src/MollomServiceProvider.php
@@ -48,7 +48,7 @@ class MollomServiceProvider extends ServiceProvider {
    * @return void
    */
   protected function registerServices() {
-    $this->app->bindShared('mollom', function ($app) {
+    $this->app->singleton('mollom', function ($app) {
       return new Client(null, $app['request']);
     });
   }


### PR DESCRIPTION
Hi,

The call to bindShared in the service manager needs to be replaced with a call to singleton to work in Laravel 5.2 or newer.

I'm not 100% sure this is the right target branch - this is my first PR, so trying to figure things out. Hope that this fix helps, though.